### PR TITLE
Replace outdated Google-Collections compile dependency with latest Guava library

### DIFF
--- a/agendacalendarview/build.gradle
+++ b/agendacalendarview/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.google.android.gms:play-services-location:8.3.0'
     compile 'com.android.support:recyclerview-v7:23.1.1'
-    compile 'com.google.collections:google-collections:1.0-rc2'
+    compile 'com.google.guava:guava:19.0'
     compile 'com.android.support:design:23.1.1'
 
     // other libraries


### PR DESCRIPTION
Removed unmaintained and outdated google-collections library(https://code.google.com/p/google-collections) and added latest guava library(https://github.com/google/guava) as suggested on old Google Collections repo page.
The old google-collections library produces issues when the calendar library is used with Guava library or other libraries dependent on Guava library(Eg. AzureMobileServicesClientSdk library). Since google-Collections is now an abandoned project, maintainers recommends to use Guava library to avoid conflicts. (Please see the links provided)
